### PR TITLE
Add HWC to Service List

### DIFF
--- a/3ds/template.rsf
+++ b/3ds/template.rsf
@@ -229,6 +229,7 @@ AccessControlInfo:
    - ir:u
    - ir:USER
    - mic:u
+   - mcu::HWC
    - ndm:u
    - news:s
    - nwm::EXT


### PR DESCRIPTION
Projects using buildtools will now be able to use functions that the HWC
service provides as explained here:
https://3dbrew.org/wiki/MCU_Services#MCU_service_.22mcu::HWC.22

Signed-off-by: Mahyar Koshkouei <mk@deltabeard.com>